### PR TITLE
Adding templates feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Add measurement templating mechanism
 
 ## 0.0.2 - 2017-05-18
 ### Added


### PR DESCRIPTION
This adds a feature to configure templates either globally on the handler's configuration or on each check's configuration.

We are using this at PTC, so far with no issues and it has been serving the purpose it was created for. Probably there are some edge cases or other perspectives that we are not covering, so comments are very welcome.

We've updated the README file with instructions and examples on how to use this feature, please let me know if this is not clear enough.